### PR TITLE
Workaround for Arm Mac

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 FDB_VER=6.2.30
-FDB_LIB_URL=https://github.com/apple/foundationdb/releases/download/6.2.30/foundationdb-clients-6.2.30-1.el7.x86_64.rpm
+FDB_LIB_URL=https://github.com/apple/foundationdb/releases/download/6.2.30/foundationdb-clients_6.2.30-1_amd64.deb
 FDB_DOCKER_IMAGE=foundationdb/foundationdb:6.2.30
 GO_URL=https://go.dev/dl/go1.19.1.linux-amd64.tar.gz
 GOLANGCI_LINT_VER=v1.49.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        fdb_ver: [6.2.30, 7.1.33]
+        fdb_ver: [6.2.30, 7.1.61]
         include:
           - fdb_ver: 6.2.30
             fdb_lib_url: https://github.com/apple/foundationdb/releases/download/6.2.30/foundationdb-clients_6.2.30-1_amd64.deb

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,11 +11,11 @@ jobs:
         fdb_ver: [6.2.30, 7.1.33]
         include:
           - fdb_ver: 6.2.30
-            fdb_lib_url: https://github.com/apple/foundationdb/releases/download/6.2.30/foundationdb-clients-6.2.30-1.el7.x86_64.rpm
+            fdb_lib_url: https://github.com/apple/foundationdb/releases/download/6.2.30/foundationdb-clients_6.2.30-1_amd64.deb
             fdb_docker_image: foundationdb/foundationdb:6.2.30
-          - fdb_ver: 7.1.33
-            fdb_lib_url: https://github.com/apple/foundationdb/releases/download/7.1.33/foundationdb-clients-7.1.33-1.el7.x86_64.rpm
-            fdb_docker_image: foundationdb/foundationdb:7.1.33
+          - fdb_ver: 7.1.61
+            fdb_lib_url: https://github.com/apple/foundationdb/releases/download/7.1.61/foundationdb-clients_7.1.61-1_amd64.deb
+            fdb_docker_image: foundationdb/foundationdb:7.1.61
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/build.sh
+++ b/build.sh
@@ -88,6 +88,7 @@ function join_array {
 function escape_quotes {
   out=()
   for arg in "$@"; do
+    # shellcheck disable=SC1003
     out+=("$(printf "'%s'" "${arg//'/\\'}")")
   done
   echo "${out[@]}"

--- a/build.sh
+++ b/build.sh
@@ -202,6 +202,7 @@ done
 
 id
 ls -ld /fdbq
+ls -ld /fdbq/*
 
 
 # Build variables required by the docker compose command.

--- a/build.sh
+++ b/build.sh
@@ -201,7 +201,7 @@ done
 # Print helpful debug info.
 
 id
-ls -ld /fdbq/*
+ls -ld /
 
 
 # Build variables required by the docker compose command.

--- a/build.sh
+++ b/build.sh
@@ -198,12 +198,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-# Print helpful debug info.
-
-id
-ls -ld /
-
-
 # Build variables required by the docker compose command.
 
 BUILD_TASKS=()

--- a/build.sh
+++ b/build.sh
@@ -201,7 +201,6 @@ done
 # Print helpful debug info.
 
 id
-ls -ld /fdbq
 ls -ld /fdbq/*
 
 

--- a/build.sh
+++ b/build.sh
@@ -198,6 +198,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 
+# Print helpful debug info.
+
+id
+ls -ld /fdbq
+
+
 # Build variables required by the docker compose command.
 
 BUILD_TASKS=()

--- a/build.sh
+++ b/build.sh
@@ -175,6 +175,11 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
 
+    --no-hado)
+      NO_HADO="x"
+      shift 1
+      ;;
+
     --help)
       print_help
       exit 0
@@ -202,7 +207,7 @@ fi
 
 if [[ -n "$VERIFY_CODEBASE" ]]; then
   BUILD_TASKS+=('./scripts/setup_database.sh')
-  BUILD_TASKS+=('./scripts/verify_codebase.sh')
+  BUILD_TASKS+=("./scripts/verify_codebase.sh ${NO_HADO:+--no-hado}")
 fi
 
 BUILD_COMMAND="$(join_array ' && ' "${BUILD_TASKS[@]}")"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
 
   # The build service is responsible for building,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
   build:
     container_name: "build"
     image: "docker.io/janderland/fdbq-build:${DOCKER_TAG}"
+    platform: "linux/amd64"
     build:
       context: "./docker"
       target: "builder"
@@ -29,6 +30,7 @@ services:
   fdbq:
     container_name: "fdbq"
     image: "docker.io/janderland/fdbq:${DOCKER_TAG}"
+    platform: "linux/amd64"
     build:
       context: "."
       dockerfile: "./docker/Dockerfile"
@@ -49,5 +51,6 @@ services:
   fdb:
     container_name: "fdb"
     image: "${FDB_DOCKER_IMAGE}"
+    platform: "linux/amd64"
     ports:
       - "4500:4500"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
     build:
       context: "./docker"
       target: "builder"
+      platforms:
+        - "linux/amd64"
       args:
         FDB_LIB_URL: "${FDB_LIB_URL}"
         GO_URL: "${GO_URL}"
@@ -34,6 +36,8 @@ services:
     build:
       context: "."
       dockerfile: "./docker/Dockerfile"
+      platforms:
+        - "linux/amd64"
       args:
         FDBQ_VER: "${DOCKER_TAG}"
         FDB_LIB_URL: "${FDB_LIB_URL}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # 'builder' includes all build & testing dependencies.
-FROM --platform=linux/amd64 debian:12 AS builder
+FROM debian:12 AS builder
 
 RUN apt update &&\
     apt install -y \
@@ -10,9 +10,8 @@ RUN apt update &&\
     apt clean
 
 ARG FDB_LIB_URL
-RUN curl -Lo fdb.deb $FDB_LIB_URL &&\
-    dpkg -i ./fdb.deb &&\
-    rm ./fdb.deb
+RUN curl -Lo /fdb.deb $FDB_LIB_URL &&\
+    dpkg -i /fdb.deb
 
 ARG GO_URL
 RUN curl -Lo go.tar.gz $GO_URL &&\
@@ -49,12 +48,11 @@ RUN go build -o /fdbq -ldflags="-X 'github.com/janderland/fdbq/internal/app.Vers
 
 
 # The final stage builds the 'fdbq' image.
-FROM --platform=linux/amd64 debian:12
+FROM debian:12
 
-ARG FDB_LIB_URL
-RUN curl -Lo fdb.deb $FDB_LIB_URL &&\
-    dpkg -i ./fdb.deb &&\
-    rm ./fdb.deb
+COPY --from=gobuild /fdb.deb /fdb.deb
+RUN dpkg -i ./fdb.deb &&\
+    rm /fdb.deb
 
 ENV TERM="xterm-256color"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,12 @@
 # 'builder' includes all build & testing dependencies.
-FROM centos:7 AS builder
+FROM --platform=linux/amd64 centos:7 AS builder
 
-RUN yum -y --setopt=skip_missing_names_on_install=False install epel-release gcc-4.8.5 &&\
-    yum -y --setopt=skip_missing_names_on_install=False install ShellCheck-0.3.8 &&\
-    yum -y --setopt=skip_missing_names_on_install=False install git-1.8.3.1 &&\
+RUN yum -y --setopt=skip_missing_names_on_install=False install \
+        epel-release \
+        gcc-4.8.5 &&\
+    yum -y --setopt=skip_missing_names_on_install=False install \
+        ShellCheck-0.3.8 \
+        git-1.8.3.1 &&\
     yum -y clean all
 
 ARG FDB_LIB_URL
@@ -36,7 +39,7 @@ RUN curl -Lo /usr/local/bin/jq $JQ_URL &&\
 
 
 # 'gobuild' executes 'go build'.
-FROM builder AS gobuild
+FROM --platform=linux/amd64 builder AS gobuild
 
 COPY . /src
 WORKDIR /src
@@ -46,7 +49,7 @@ RUN go build -o /fdbq -ldflags="-X 'github.com/janderland/fdbq/internal/app.Vers
 
 
 # The final stage builds the 'fdbq' image.
-FROM centos:7
+FROM --platform=linux/amd64 centos:7
 
 ARG FDB_LIB_URL
 RUN curl -Lo fdb.rpm $FDB_LIB_URL &&\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,12 +2,14 @@
 FROM debian:12 AS builder
 
 RUN apt-get update &&\
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
       build-essential=12.9 \
+      ca-certificates=20230311 \
       shellcheck=0.9.0-1 \
       git=1:2.39.2-1.1 \
       curl=7.88.1-10+deb12u6 &&\
-    apt-get clean
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
 
 ARG FDB_LIB_URL
 RUN curl -Lo /fdb.deb $FDB_LIB_URL &&\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,13 @@
 # 'builder' includes all build & testing dependencies.
 FROM debian:12 AS builder
 
-RUN apt update &&\
-    apt install -y \
+RUN apt-get update &&\
+    apt-get install -y \
       build-essential \
       shellcheck=0.9.0-1 \
       git=1:2.39.2-1.1 \
       curl=7.88.1-10+deb12u6 &&\
-    apt clean
+    apt-get clean
 
 ARG FDB_LIB_URL
 RUN curl -Lo /fdb.deb $FDB_LIB_URL &&\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,18 @@
 # 'builder' includes all build & testing dependencies.
-FROM --platform=linux/amd64 centos:7 AS builder
+FROM --platform=linux/amd64 debian:12 AS builder
 
-RUN yum -y --setopt=skip_missing_names_on_install=False install \
-        epel-release \
-        gcc-4.8.5 &&\
-    yum -y --setopt=skip_missing_names_on_install=False install \
-        ShellCheck-0.3.8 \
-        git-1.8.3.1 &&\
-    yum -y clean all
+RUN apt update &&\
+    apt install -y \
+      build-essential \
+      shellcheck=0.9.0-1 \
+      git=1:2.39.2-1.1 \
+      curl=7.88.1-10+deb12u6 &&\
+    apt clean
 
 ARG FDB_LIB_URL
-RUN curl -Lo fdb.rpm $FDB_LIB_URL &&\
-    rpm -i ./fdb.rpm &&\
-    rm ./fdb.rpm
+RUN curl -Lo fdb.deb $FDB_LIB_URL &&\
+    dpkg -i ./fdb.deb &&\
+    rm ./fdb.deb
 
 ARG GO_URL
 RUN curl -Lo go.tar.gz $GO_URL &&\
@@ -49,12 +49,12 @@ RUN go build -o /fdbq -ldflags="-X 'github.com/janderland/fdbq/internal/app.Vers
 
 
 # The final stage builds the 'fdbq' image.
-FROM --platform=linux/amd64 centos:7
+FROM --platform=linux/amd64 debian:12
 
 ARG FDB_LIB_URL
-RUN curl -Lo fdb.rpm $FDB_LIB_URL &&\
-    rpm -i ./fdb.rpm              &&\
-    rm ./fdb.rpm
+RUN curl -Lo fdb.deb $FDB_LIB_URL &&\
+    dpkg -i ./fdb.deb &&\
+    rm ./fdb.deb
 
 ENV TERM="xterm-256color"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,12 @@ ARG JQ_URL
 RUN curl -Lo /usr/local/bin/jq $JQ_URL &&\
     chmod +x /usr/local/bin/jq
 
+# Configure git so it allows any user to run git commands
+# on the /fdbq directory. This allows the user which runs
+# CI to be different from the user which built the Docker
+# image.
+RUN git config --global --add safe.directory /fdbq
+
 
 # 'gobuild' executes 'go build'.
 FROM --platform=linux/amd64 builder AS gobuild

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:12 AS builder
 
 RUN apt-get update &&\
     apt-get install -y \
-      build-essential \
+      build-essential=12.9 \
       shellcheck=0.9.0-1 \
       git=1:2.39.2-1.1 \
       curl=7.88.1-10+deb12u6 &&\
@@ -44,7 +44,7 @@ RUN git config --global --add safe.directory /fdbq
 
 
 # 'gobuild' executes 'go build'.
-FROM --platform=linux/amd64 builder AS gobuild
+FROM builder AS gobuild
 
 COPY . /src
 WORKDIR /src

--- a/scripts/verify_codebase.sh
+++ b/scripts/verify_codebase.sh
@@ -6,9 +6,6 @@ cd "${0%/*}/.."
 
 set -x
 
-id
-ls -ld /fdbq
-
 # Lint shell scripts.
 find . -type f -iname '*.sh' -print0 | xargs -t -0 shellcheck
 

--- a/scripts/verify_codebase.sh
+++ b/scripts/verify_codebase.sh
@@ -9,10 +9,12 @@ set -x
 # Lint shell scripts.
 find . -type f -iname '*.sh' -print0 | xargs -t -0 shellcheck
 
-# Lint Dockerfiles.
-find . -type f -iname 'Dockerfile' -print0 | xargs -t -0 -n 1 hadolint
+# Lint Dockerfiles, if the '--no-hado' flag wasn't passed.
+if [[ "${1:-}" != '--no-hado' ]]; then
+  find . -type f -iname 'Dockerfile' -print0 | xargs -t -0 -n 1 hadolint
+fi
 
-# build, lint, & test Go code.
+# Build, lint, & test Go code.
 go build ./...
 golangci-lint run ./...
 go test ./...

--- a/scripts/verify_codebase.sh
+++ b/scripts/verify_codebase.sh
@@ -6,6 +6,9 @@ cd "${0%/*}/.."
 
 set -x
 
+id
+ls -ld /fdbq
+
 # Lint shell scripts.
 find . -type f -iname '*.sh' -print0 | xargs -t -0 shellcheck
 

--- a/scripts/verify_generation.sh
+++ b/scripts/verify_generation.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 # Change directory to repo root.
 cd "${0%/*}/.."
 
+id
+ls -ld /fdbq
+
 STATUS="$(git status --short)"
 if [[ -n "$STATUS" ]]; then
   echo "ERR! Generated code cannot be verified while there are uncommitted changes."

--- a/scripts/verify_generation.sh
+++ b/scripts/verify_generation.sh
@@ -4,9 +4,6 @@ set -euo pipefail
 # Change directory to repo root.
 cd "${0%/*}/.."
 
-id
-ls -ld /fdbq
-
 STATUS="$(git status --short)"
 if [[ -n "$STATUS" ]]; then
   echo "ERR! Generated code cannot be verified while there are uncommitted changes."


### PR DESCRIPTION
- Hadolint segfaults in a Intel container running on Arm Mac. This PR adds a flag which will skip running hadolint.
- Move CI base image from CentOS to Debian.